### PR TITLE
fix: regex matcher now more obvious behaviour

### DIFF
--- a/beancount_importer_rules/processor/matchers.py
+++ b/beancount_importer_rules/processor/matchers.py
@@ -1,109 +1,32 @@
 import pathlib
-import re
-
-import arrow
 
 from beancount_importer_rules.data_types import (
-    DateAfterMatch,
-    DateBeforeMatch,
-    DateSameDayMatch,
-    DateSameMonthMatch,
-    DateSameYearMatch,
-    SimpleFileMatch,
     SimpleTxnMatchRule,
-    StrContainsMatch,
-    StrExactMatch,
     StrMatch,
-    StrOneOfMatch,
-    StrPrefixMatch,
     StrRegexMatch,
-    StrSuffixMatch,
     Transaction,
     TxnMatchVars,
 )
 
 
-def match_file(
-    pattern: SimpleFileMatch, filepath: pathlib.Path | pathlib.PurePath
-) -> bool:
+def match_file(pattern: StrMatch, filepath: pathlib.Path | pathlib.PurePath) -> bool:
     if isinstance(pattern, str):
         return filepath.match(pattern)
-    if isinstance(pattern, StrRegexMatch):
-        return re.match(pattern.regex, str(filepath)) is not None
-    elif isinstance(pattern, StrExactMatch):
-        return str(filepath) == pattern.equals
-    else:
-        raise ValueError(f"Unexpected file match type {type(pattern)}")
+
+    return pattern.test(str(filepath))
 
 
 def match_str(pattern: StrMatch | None, value: str | None) -> bool:
     if value is None:
         return False
 
+    if pattern is None:
+        return True
+
     if isinstance(pattern, str):
-        return re.match(pattern, value) is not None
-    elif isinstance(pattern, StrRegexMatch):
-        return re.match(pattern.regex, value) is not None
-    elif isinstance(pattern, StrExactMatch):
-        return value == pattern.equals
-    elif isinstance(pattern, StrPrefixMatch):
-        return value.startswith(pattern.prefix)
-    elif isinstance(pattern, StrSuffixMatch):
-        return value.endswith(pattern.suffix)
-    elif isinstance(pattern, StrContainsMatch):
-        return pattern.contains in value
-    elif isinstance(pattern, StrOneOfMatch):
-        return value in pattern.one_of
-    elif isinstance(pattern, DateAfterMatch):
-        # is the value string a date and does the date occur after the date in the pattern
-        try:
-            value_as_date = arrow.get(value, pattern.format)
-            match_date = arrow.get(pattern.date_after, pattern.format)
-            return match_date < value_as_date
-        except ValueError:
-            return False
+        pattern = StrRegexMatch(regex=pattern)
 
-    elif isinstance(pattern, DateBeforeMatch):
-        # is the value string a date and does the date occur before the date in the pattern
-        try:
-            value_as_date = arrow.get(value, pattern.format)
-            match_date = arrow.get(pattern.date_before, pattern.format)
-            return match_date > value_as_date
-        except ValueError:
-            return False
-
-    elif isinstance(pattern, DateSameDayMatch):
-        try:
-            # reduce the value to the day only
-            value_as_date = arrow.get(value, pattern.format).floor("day")
-            match_date = arrow.get(pattern.date_same_day, pattern.format).floor("day")
-            return value_as_date == match_date
-        except ValueError:
-            return False
-
-    elif isinstance(pattern, DateSameMonthMatch):
-        try:
-            # reduce the value to the month only
-            value_as_date = arrow.get(value, pattern.format).floor("month")
-            match_date = arrow.get(pattern.date_same_month, pattern.format).floor(
-                "month"
-            )
-            # set the day to 1 to compare only the month
-            return value_as_date == match_date
-        except ValueError:
-            return False
-
-    elif isinstance(pattern, DateSameYearMatch):
-        try:
-            # reduce the value to the year only
-            value_as_date = arrow.get(value, pattern.format).floor("year")
-            match_date = arrow.get(pattern.date_same_year, pattern.format).floor("year")
-            # set the day and month to 1 to compare only the year
-            return value_as_date == match_date
-        except ValueError:
-            return False
-    else:
-        raise ValueError(f"Unexpected str match type {type(pattern)}")
+    return pattern.test(value)
 
 
 def match_transaction(
@@ -129,7 +52,10 @@ def match_transaction_with_vars(
     common_condition: SimpleTxnMatchRule | None = None,
 ) -> TxnMatchVars | None:
     for rule in rules:
-        if match_transaction(txn, rule.cond) and (
-            common_condition is None or match_transaction(txn, common_condition)
-        ):
+        matches_rule = match_transaction(txn, rule.cond)
+        matches_common = (
+            match_transaction(txn, common_condition) if common_condition else True
+        )
+
+        if matches_rule and matches_common:
             return rule

--- a/tests/test_match_transaction_withvars.py
+++ b/tests/test_match_transaction_withvars.py
@@ -1,5 +1,3 @@
-import pytest
-
 from beancount_importer_rules.data_types import (
     SimpleTxnMatchRule,
     StrExactMatch,
@@ -9,93 +7,83 @@ from beancount_importer_rules.data_types import (
 from beancount_importer_rules.processor.matchers import match_transaction_with_vars
 
 
-@pytest.mark.parametrize(
-    "txn, rules, common_cond, expected",
-    [
-        (
-            Transaction(extractor="MOCK_EXTRACTOR"),
-            [
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
-                ),
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(
-                        extractor=StrExactMatch(equals="MOCK_EXTRACTOR")
-                    ),
-                    vars=dict(foo="bar"),
-                ),
-            ],
-            None,
-            TxnMatchVars(
-                cond=SimpleTxnMatchRule(
-                    extractor=StrExactMatch(equals="MOCK_EXTRACTOR")
-                ),
-                vars=dict(foo="bar"),
-            ),
+def test_match_transaction_with_vars_empty():
+    txn = Transaction(extractor="MOCK_EXTRACTOR")
+    rules = [
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
         ),
-        (
-            Transaction(extractor="MOCK_EXTRACTOR"),
-            [
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
-                    vars=dict(eggs="spam"),
-                ),
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(
-                        extractor=StrExactMatch(equals="MOCK_EXTRACTOR")
-                    ),
-                    vars=dict(foo="bar"),
-                ),
-            ],
-            SimpleTxnMatchRule(payee=StrExactMatch(equals="PAYEE")),
-            None,
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="MOCK_EXTRACTOR")),
+            vars=dict(foo="bar"),
         ),
-        (
-            Transaction(extractor="MOCK_EXTRACTOR", payee="PAYEE"),
-            [
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
-                    vars=dict(eggs="spam"),
-                ),
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(
-                        extractor=StrExactMatch(equals="MOCK_EXTRACTOR")
-                    ),
-                    vars=dict(foo="bar"),
-                ),
-            ],
-            SimpleTxnMatchRule(payee=StrExactMatch(equals="PAYEE")),
-            TxnMatchVars(
-                cond=SimpleTxnMatchRule(
-                    extractor=StrExactMatch(equals="MOCK_EXTRACTOR")
-                ),
-                vars=dict(foo="bar"),
-            ),
-        ),
-        (
-            Transaction(extractor="MOCK_EXTRACTOR"),
-            [
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
-                    vars=dict(eggs="spam"),
-                ),
-                TxnMatchVars(
-                    cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="NOPE")),
-                    vars=dict(foo="bar"),
-                ),
-            ],
-            None,
-            None,
-        ),
-    ],
-)
-def test_match_transaction_with_vars(
-    txn: Transaction,
-    rules: list[TxnMatchVars],
-    common_cond: SimpleTxnMatchRule | None,
-    expected: TxnMatchVars,
-):
-    assert (
-        match_transaction_with_vars(txn, rules, common_condition=common_cond)
-        == expected
+    ]
+
+    common_cond = None
+    expected = TxnMatchVars(
+        cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="MOCK_EXTRACTOR")),
+        vars=dict(foo="bar"),
     )
+
+    outcome = match_transaction_with_vars(txn, rules, common_condition=common_cond)
+
+    assert outcome == expected
+
+
+def test_match_transaction_with_common_cond():
+    txn = Transaction(extractor="MOCK_EXTRACTOR")
+    rules = [
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
+            vars=dict(eggs="spam"),
+        ),
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="MOCK_EXTRACTOR")),
+            vars=dict(foo="bar"),
+        ),
+    ]
+    common_cond = SimpleTxnMatchRule(payee=StrExactMatch(equals="PAYEE"))
+    expected = None
+    outcome = match_transaction_with_vars(txn, rules, common_condition=common_cond)
+    assert outcome == expected
+
+
+def test_match_transaction_with_vars_common():
+    txn = Transaction(extractor="MOCK_EXTRACTOR", payee="PAYEE")
+    rules = [
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
+            vars=dict(eggs="spam"),
+        ),
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="MOCK_EXTRACTOR")),
+            vars=dict(foo="bar"),
+        ),
+    ]
+
+    common_cond = SimpleTxnMatchRule(payee=StrExactMatch(equals="PAYEE"))
+    expected = TxnMatchVars(
+        cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="MOCK_EXTRACTOR")),
+        vars=dict(foo="bar"),
+    )
+    outcome = match_transaction_with_vars(txn, rules, common_condition=common_cond)
+    assert outcome == expected
+
+
+def test_match_transaction_with_vars():
+    txn = Transaction(extractor="MOCK_EXTRACTOR")
+    rules = [
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="OTHER")),
+            vars=dict(eggs="spam"),
+        ),
+        TxnMatchVars(
+            cond=SimpleTxnMatchRule(extractor=StrExactMatch(equals="NOPE")),
+            vars=dict(foo="bar"),
+        ),
+    ]
+    common_cond = None
+    expected = None
+    outcome = match_transaction_with_vars(txn, rules, common_condition=common_cond)
+
+    assert outcome == expected


### PR DESCRIPTION
The StrRegexMatch now uses re.search so that patterns can be used to test if they exist anywhere in the string.

To return to the previous behaviour of only matching values that start with the pattern, you need to use `^`.

This also means we can more reliably use `$` to say that a value must end with the pattern.

- All matcher DataTypes now provide their own `test` method.
- `match_file` now allows any matcher type.