### PR TITLE
fix: support matching between dates and better regex handling

### DIFF
--- a/beancount_importer_rules/data_types.py
+++ b/beancount_importer_rules/data_types.py
@@ -27,11 +27,11 @@ class Transaction:
     # the unique id of the transaction
     transaction_id: str | None = None
     # date of the transaction
-    date: datetime.date | None = None
+    date: str | None = None
     # date when the transaction posted
-    post_date: datetime.date | None = None
+    post_date: str | None = None
     # timestamp of the transaction
-    timestamp: datetime.datetime | None = None
+    timestamp: str | None = None
     # timezone of the transaction, needs to be one of timezone value supported by pytz
     timezone: str | None = None
     # description of the transaction
@@ -269,6 +269,43 @@ class DateBeforeMatch(MatchBaseModel):
             return False
 
 
+class DateBetweenMatch(MatchBaseModel):
+    """
+    To match values between two dates, one can do this:
+
+    ```YAML
+    imports:
+    - match:
+        date:
+          date_before: "2021-01-01"
+          date_after: "2020-01-01"
+          format: "%Y-%m-%d"
+    ```
+
+    """
+
+    date_before: str
+    """ The date to match before"""
+    date_after: str
+    """ The date to match after"""
+    format: str
+    """ The format of the date. used to parse the value date and the date to match"""
+
+    def __str__(self) -> str:
+        return f"date_before:{self.date_before}"
+
+    def test(self, value: str) -> bool:
+        try:
+            value_as_date = arrow.get(value, self.format)
+            match_date_before = arrow.get(self.date_before, self.format)
+            match_date_after = arrow.get(self.date_after, self.format)
+            return (
+                match_date_before > value_as_date and match_date_after < value_as_date
+            )
+        except ValueError:
+            return False
+
+
 class DateAfterMatch(MatchBaseModel):
     """
     To match values after a date, one can do this:
@@ -407,6 +444,7 @@ StrMatch = (
     | DateSameDayMatch
     | DateSameMonthMatch
     | DateSameYearMatch
+    | DateBetweenMatch
 )
 
 

--- a/beancount_importer_rules/processor/matchers.py
+++ b/beancount_importer_rules/processor/matchers.py
@@ -1,12 +1,22 @@
 import pathlib
+import re
 
 from beancount_importer_rules.data_types import (
     SimpleTxnMatchRule,
+    StrExactMatch,
     StrMatch,
     StrRegexMatch,
     Transaction,
     TxnMatchVars,
 )
+
+
+def is_valid_regex(pattern: str) -> bool:
+    try:
+        re.compile(pattern)
+        return True
+    except re.error:
+        return False
 
 
 def match_file(pattern: StrMatch, filepath: pathlib.Path | pathlib.PurePath) -> bool:
@@ -23,8 +33,14 @@ def match_str(pattern: StrMatch | None, value: str | None) -> bool:
     if pattern is None:
         return True
 
+    if pattern == value:
+        return True
+
+    if isinstance(pattern, str) and is_valid_regex(pattern):
+        return StrRegexMatch(regex=pattern).test(value)
+
     if isinstance(pattern, str):
-        pattern = StrRegexMatch(regex=pattern)
+        return StrExactMatch(equals=pattern).test(value)
 
     return pattern.test(value)
 


### PR DESCRIPTION
new date matcher `DateBetweenMatch` 

```YAML
    imports:
    - match:
        date:
          date_before: "2021-01-01"
          date_after: "2020-01-01"
          format: "YYYY-MM-DD"
```

Fixed handling of dates as exact match being mistakenly treated as regex pattern: 

```yaml
    imports:
    - match:
         date: 2020-01-01
```

would be treated as regex.

`Transaction.date` is now a string instead of a `datetime.date` which is related to the above error.